### PR TITLE
manifest_versionを3へ更新

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,5 +1,5 @@
 {
-    "manifest_version": 2,
+    "manifest_version": 3,
     "name": "cometsにカスタムボタン追加するくん",
     "version": "1.0",
     "description": "cometsにカスタムボタンを追加します。",


### PR DESCRIPTION
拡張機能を入れたところ

```
Manifest version 2 is deprecated, and support will be removed in 2023. See https://developer.chrome.com/blog/mv2-transition/ for more details.
```

と警告が出てたので3に上げました
動作確認済み